### PR TITLE
Fix documentation for recent nightlies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ use std::{fmt, ops, str};
 /// This type differs from `std::String` in that it is generic over the
 /// underlying byte storage, enabling it to use `Vec<[u8]>`, `&[u8]`, or third
 /// party types, such as [`Bytes`].
+///
+/// [`Bytes`]: https://docs.rs/bytes/0.4.8/bytes/struct.Bytes.html
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct String<T = Vec<u8>> {
     value: T,


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/commit/b000cf07261af68c7aa47e10140c692bc03c85da, rustdoc produces warnings on markdown link resolution failures. `#![deny(warnings)]` is set in this crate so any warnings cause the build to fail.

Example failure when running `cargo doc`:

    Documenting string v0.1.0 (file:///.../string)
    error: `[Bytes]` cannot be resolved, ignoring it...
      --> src/lib.rs:26:27
       |
    26 | /// party types, such as [`Bytes`].
       |                           ^^^^^^^ cannot be resolved, ignoring
       |
    note: lint level defined here
      --> src/lib.rs:17:9
       |
    17 | #![deny(warnings, missing_docs, missing_debug_implementations)]
       |         ^^^^^^^^
       = note: #[deny(intra_doc_link_resolution_failure)] implied by #[deny(warnings)]
       = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

    error: Could not document `string`.

    Caused by:
      process didn't exit successfully: `rustdoc --crate-name string src/lib.rs -o /.../string/target/doc -L dependency=/.../string/target/debug/deps` (exit code: 101) 


This also affects generating documentation on downstream crates, e.g. running `cargo doc` in https://github.com/tower-rs/tower fails on recent nightlies.

I've opted to remove the square brackets rather than escape them, as I don't think they convey any additional semantic meaning.