### PR TITLE
impl StableAsRef for Bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       rust: 1.20.0
 
 script:
+  - cargo build --no-default-features
+  - cargo test --no-default-features
   - cargo build
   - cargo test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,12 @@ readme = "README.md"
 keywords = ["string"]
 categories = ["data-structures"]
 
+[features]
+default = ["bytes"]
+
 [badges.travis-ci]
 repository = "carllerche/string"
 branch = "master"
 
 [dependencies]
+bytes = { version = "0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@
 //! assert_eq!(&s[..], "hi");
 //! ```
 
+#[cfg(feature = "bytes")]
+extern crate bytes;
+
 use std::{borrow, fmt, hash, ops, str};
 use std::default::Default;
 
@@ -278,6 +281,12 @@ unsafe impl StableAsRef for std::string::String {}
 unsafe impl StableAsRef for str {}
 unsafe impl StableAsRef for Vec<u8> {}
 unsafe impl StableAsRef for [u8] {}
+
+#[cfg(feature = "bytes")]
+unsafe impl StableAsRef for bytes::Bytes {}
+
+#[cfg(feature = "bytes")]
+unsafe impl StableAsRef for bytes::BytesMut {}
 
 macro_rules! array_impls {
     ($($len:expr)+) => {


### PR DESCRIPTION
This enables `Bytes` to be used as storage for `String`.

cc @srijs, @seanmonstar