### PR TITLE
Enable `bytes` to build with no rust version limit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,12 @@ rust:
 os:
   - linux
 
-matrix:
-  include:
-    - os: linux
-
 script:
   - cargo build --no-default-features
   - cargo test --no-default-features
   - if [ "${TRAVIS_RUST_VERSION}" != "1.20.0" ]; then
-      cargo build
-      cargo test
+      cargo build;
+      cargo test;
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 rust:
   - stable
+  - 1.20.0
 
 os:
   - linux
@@ -11,13 +12,14 @@ os:
 matrix:
   include:
     - os: linux
-      rust: 1.20.0
 
 script:
   - cargo build --no-default-features
   - cargo test --no-default-features
-  - cargo build
-  - cargo test
+  - if [ "${TRAVIS_RUST_VERSION}" != "1.20.0" ]; then
+      cargo build
+      cargo test
+    fi
 
 notifications:
   email:


### PR DESCRIPTION
#17 is currently stuck because `bytes` doesn't support rust `1.20.0` anymore. This should alleviate the issue.