### PR TITLE
Update to rust edition 2018.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ os:
 matrix:
   include:
     - os: linux
-      rust: 1.20.0
+      rust: 1.39.0
 
 script:
   - cargo build --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/carllerche/string"
 readme = "README.md"
 keywords = ["string"]
 categories = ["data-structures"]
+edition = "2018"
 
 [features]
 default = ["bytes"]
@@ -25,4 +26,4 @@ repository = "carllerche/string"
 branch = "master"
 
 [dependencies]
-bytes = { version = "0.4", optional = true }
+bytes = { version = "0.5", optional = true }


### PR DESCRIPTION
I can additionally run `rustfmt` and add `clippy` if you want?