### PR TITLE
Implement `PartialEq`, `PartialOrd` and `Ord` via the dereferenced `str`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! assert_eq!(&s[..], "hi");
 //! ```
 
-use std::{borrow, default::Default, fmt, hash, ops, str};
+use std::{borrow, cmp, default::Default, fmt, hash, ops, str};
 
 /// A UTF-8 encoded string with configurable byte storage.
 ///
@@ -31,7 +31,7 @@ use std::{borrow, default::Default, fmt, hash, ops, str};
 /// you can use the `from_utf8_unchecked` constructor.
 ///
 /// [`Bytes`]: https://docs.rs/bytes/0.4.8/bytes/struct.Bytes.html
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone)]
 pub struct String<T = Vec<u8>> {
     value: T,
 }
@@ -142,6 +142,17 @@ where
     }
 }
 
+impl<T> PartialEq for String<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl<T> Eq for String<T> where T: AsRef<[u8]> {}
+
 impl<T> PartialEq<str> for String<T>
 where
     T: AsRef<[u8]>,
@@ -151,7 +162,24 @@ where
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+impl<T> PartialOrd for String<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        (**self).partial_cmp(&**other)
+    }
+}
+
+impl<T> Ord for String<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        (**self).cmp(&**other)
+    }
+}
+
 impl<T> hash::Hash for String<T>
 where
     T: AsRef<[u8]>,


### PR DESCRIPTION
The [documentation of `Borrow`][borrow] says that `Eq`, `Ord` and `Hash` implementation of a type which implements `Borrow<T>` must behave identical to `T`. On the other hand, `String<T>` implements those traits with `#[derive]`, which does not necessarily comply with that contract.

[borrow]: https://doc.rust-lang.org/1.48.0/std/borrow/trait.Borrow.html

In particular, the following test (code adapted from the documentation of `Borrow`) should pass, which currently fails.

```rust
#[derive(Debug)]
struct CaseInsensitiveStr<'a>(&'a str);
impl<'a> AsRef<[u8]> for CaseInsensitiveStr<'a> {
    fn as_ref(&self) -> &[u8] {
        self.0.as_bytes()
    }
}
unsafe impl<'a> StableAsRef for CaseInsensitiveStr<'a> {}

impl<'a> PartialEq for CaseInsensitiveStr<'a> {
    fn eq(&self, other: &Self) -> bool {
        self.0.eq_ignore_ascii_case(&other.0)
    }
}
impl<'a> Eq for CaseInsensitiveStr<'a> {}

let s = CaseInsensitiveStr("hello");
let t = CaseInsensitiveStr("HELLO");

assert_eq!(s, t);

let s = String::try_from(s).unwrap();
let t = String::try_from(t).unwrap();
assert_ne!(s, t);
assert_ne!(Borrow::<str>::borrow(&s), Borrow::<str>::borrow(&t));
```

In addition, current implementations (since 487f10797850b082f8215c58fb7e7eac5f3bcebb?) can violate `Hash` trait's contract (`k1 == k2 -> hash(k1) == hash(k2)`) depending on the underlying type.