### PR TITLE
Implement `StableAsRef` for `u8` arrays of arbitrary length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ os:
 matrix:
   include:
     - os: linux
-      rust: 1.39.0
+      rust: 1.51.0
 
 script:
   - cargo build --no-default-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,22 +292,13 @@ unsafe impl StableAsRef for std::string::String {}
 unsafe impl StableAsRef for str {}
 unsafe impl StableAsRef for Vec<u8> {}
 unsafe impl StableAsRef for [u8] {}
+unsafe impl<const N: usize> StableAsRef for [u8; N] {}
 
 #[cfg(feature = "bytes")]
 unsafe impl StableAsRef for bytes::Bytes {}
 
 #[cfg(feature = "bytes")]
 unsafe impl StableAsRef for bytes::BytesMut {}
-
-macro_rules! array_impls {
-    ($($len:expr)+) => {
-        $(
-            unsafe impl StableAsRef for [u8; $len] {}
-        )+
-    }
-}
-
-array_impls!(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
This change uses const generics and increases the MSRV to [1.51.0], which was released 7 months ago.

[1.51.0]: <https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html>